### PR TITLE
properly get USER_SESSION_STRING from config.env

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -99,8 +99,8 @@ except KeyError as e:
 
 # Generate USER_SESSION_STRING, if not exists
 try:
-    if bool(os.environ['USER_SESSION_STRING']):
-        USER_SESSION_STRING = os.environ['USER_SESSION_STRING']
+    if bool(getConfig('USER_SESSION_STRING')):
+        USER_SESSION_STRING = getConfig('USER_SESSION_STRING') 
         pass
 except KeyError:
     LOGGER.info("Generating USER_SESSION_STRING")


### PR DESCRIPTION
changed os.environ to getConfig
not entirely sure if it would work or not, but give it a shot.
revert changes if it doesn't work.